### PR TITLE
support simultanoues horizontal and vertical keys in pc

### DIFF
--- a/mt_gradius/src/gradius_controller_event.js
+++ b/mt_gradius/src/gradius_controller_event.js
@@ -490,16 +490,24 @@ const _KEYEVENT={
 	}
 
 	if(e.key==='ArrowLeft'||e.key==='Left'){
-		_PARTS_PLAYERMAIN._set_move_players({x:-1,y:0});
+		_PARTS_PLAYERMAIN._set_pc_keystateX(-1);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		_PARTS_PLAYERMAIN._set_move_players(p);
 	}
 	if(e.key==='ArrowRight'||e.key==='Right'){
-		_PARTS_PLAYERMAIN._set_move_players({x:1,y:0});
+		_PARTS_PLAYERMAIN._set_pc_keystateX(1);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		_PARTS_PLAYERMAIN._set_move_players(p);
 	}
 	if(e.key==='ArrowUp'||e.key==='Up'){
-		_PARTS_PLAYERMAIN._set_move_players({x:0,y:-1});
+		_PARTS_PLAYERMAIN._set_pc_keystateY(-1);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		_PARTS_PLAYERMAIN._set_move_players(p);
 	}
 	if(e.key==='ArrowDown'||e.key==='Down'){
-		_PARTS_PLAYERMAIN._set_move_players({x:0,y:1});
+		_PARTS_PLAYERMAIN._set_pc_keystateY(1);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		_PARTS_PLAYERMAIN._set_move_players(p);
 	}
 	//装備
 	if(e.key==='B'||e.key==='b'){
@@ -523,16 +531,40 @@ const _KEYEVENT={
 
 'keyup_game':function(e){
 	if(e.key==='ArrowLeft'||e.key==='Left'){
-		_PARTS_PLAYERMAIN._set_stop_players();
+		_PARTS_PLAYERMAIN._set_pc_keystateX(0);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		if (p.x == 0 && p.y == 0) {
+			_PARTS_PLAYERMAIN._set_stop_players();
+		} else {
+			_PARTS_PLAYERMAIN._set_move_players(p);
+		}
 	}
 	if(e.key==='ArrowRight'||e.key==='Right'){
-		_PARTS_PLAYERMAIN._set_stop_players();
+		_PARTS_PLAYERMAIN._set_pc_keystateX(0);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		if (p.x == 0 && p.y == 0) {
+			_PARTS_PLAYERMAIN._set_stop_players();
+		} else {
+			_PARTS_PLAYERMAIN._set_move_players(p);
+		}
 	}
 	if(e.key==='ArrowUp'||e.key==='Up'){
-		_PARTS_PLAYERMAIN._set_stop_players();
+		_PARTS_PLAYERMAIN._set_pc_keystateY(0);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		if (p.x == 0 && p.y == 0) {
+			_PARTS_PLAYERMAIN._set_stop_players();
+		} else {
+			_PARTS_PLAYERMAIN._set_move_players(p);
+		}
 	}
 	if(e.key==='ArrowDown'||e.key==='Down'){
-		_PARTS_PLAYERMAIN._set_stop_players();
+		_PARTS_PLAYERMAIN._set_pc_keystateY(0);
+		var p = _PARTS_PLAYERMAIN._get_move_from_pc_keystate();
+		if (p.x == 0 && p.y == 0) {
+			_PARTS_PLAYERMAIN._set_stop_players();
+		} else {
+			_PARTS_PLAYERMAIN._set_move_players(p);
+		}
 	}
 	if(e.key===' '||e.key==='Spacebar'){
 		_DRAW_STOP_PLAYERS_SHOTS();

--- a/mt_gradius/src/gradius_parts_playermain.js
+++ b/mt_gradius/src/gradius_parts_playermain.js
@@ -53,6 +53,8 @@ const _PARTS_PLAYERMAIN={
 	_move_drawY_moves:new Array(),
 	_move_draw_max:50,
 
+	_pc_keystate: {x:0, y:0},
+
 	_reset(){
 		//以下定義をリセット
 		let _this=this;
@@ -79,6 +81,7 @@ const _PARTS_PLAYERMAIN={
 		_this._move_drawX = new Array();
 		_this._move_drawY = new Array();
 
+		_this._pc_keystate = {x:0, y:0};
 	},
 
 	_draw_players(){
@@ -86,6 +89,30 @@ const _PARTS_PLAYERMAIN={
 		//自機とフォース・シールドの表示処理
 		_this._players_force_obj.setDrawImage();
 		if(_this._players_obj.isalive()){_this._players_obj.setDrawImage();}
+	},
+	_set_pc_keystateX(x){
+		let _this = this;
+		_this._pc_keystate.x = x;
+	},
+	_set_pc_keystateY(y){
+		let _this = this;
+		_this._pc_keystate.y = y;
+	},
+	_get_move_from_pc_keystate(){
+		let _this = this;
+		if (_this._pc_keystate.y == 0) {
+			if (_this._pc_keystate.x == 0) {
+				return {x:0, y:0};
+			} else {
+				return {x:_this._pc_keystate.x, y:0};
+			}
+		} else {
+			if (_this._pc_keystate.x == 0) {
+				return {x:0, y:_this._pc_keystate.y};
+			} else {
+				return {x:_this._pc_keystate.x*(1.0/Math.sqrt(2)), y:_this._pc_keystate.y*(1.0/Math.sqrt(2))};
+			}
+		}
 	},
 	_set_move_players(_p){
 		let _this = this;


### PR DESCRIPTION
PCでのプレイ時に、斜め移動が出来ないようでしたので、斜め移動するように
実装してみました。

具体的には、例えば、上矢印押下したまま左矢印押下で、左上に移動する状態になる、
ということです。

(なお、dist/gradis.htmlはビルド後に上書きされるので、コミットしませんでした)

プルリクエストとしていますが、既存のコードとの整合性もあると思うので、
参考程度に見ていただければと思います。（マージしなくて良いと思います）

P.S. まだこのゲームのステージ1をクリア出来ません。ボスまでたどり着くのが
やっとです。


